### PR TITLE
Fix: try fix `sed: can't read : No such file or directory` problem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,11 @@ ifeq (, $(shell which wasm-pack))
 endif
 	wasm-pack build --scope kong --release --out-name atc-router
 	# rename the package to "@kong/atc-router": wasm-pack does not support this yet
-	sed -i '' -e 's#"name": "@kong/atc-router-wasm"#"name": "@kong/atc-router"#g' pkg/package.json
+	@# Check the operating system and use appropriate sed command
+	@case "$$(uname -s)" in \
+	    Darwin*) sed -i '' -e 's#"name": "@kong/atc-router-wasm"#"name": "@kong/atc-router"#g' pkg/package.json ;; \
+	    *) sed -i -e 's#"name": "@kong/atc-router-wasm"#"name": "@kong/atc-router"#g' pkg/package.json ;; \
+	esac
 
 publish:
 ifeq (, $(shell which npm))


### PR DESCRIPTION
There appears to be a difference in behavior between macOS and Linux when using the `-i` flag with `sed`. In my environment, the `sed --version` output is:

```
sed (GNU sed) 4.9
Copyright (C) 2022 Free Software Foundation, Inc.
```

This causes the `make build` command to fail with the following error:

```
...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: Optional field missing from Cargo.toml: 'license'. This is not necessary, but recommended
[INFO]: ✨   Done in 16.87s
[INFO]: 📦   Your wasm pkg is ready to publish at /home/path/to/atc-router-wasm/pkg.
# rename the package to "@kong/atc-router": wasm-pack does not support this yet
sed -i '' -e 's#"name": "@kong/atc-router-wasm"#"name": "@kong/atc-router"#g' pkg/package.json
sed: can't read : No such file or directory
make: *** [Makefile:14: build] Error 2
```

It seems that `-i ''` works on macOS but not on Linux. This PR aims to address this issue.

As I don't own a macOS device, I'm not entirely sure if this will continue to work on macOS. 😅