### PR TITLE
Change quick start link to main site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ WebAssembly bindings for Kong's [ATC Router library](https://github.com/Kong/atc
 
 ## Build
 
-1. Install wasm-pack via the [quick start](https://rustwasm.github.io/wasm-pack/book/quickstart.html) guide or ...
+1. Install wasm-pack via the [quick start](https://rustwasm.github.io/docs/wasm-pack/quickstart.html) guide or ...
    ```shell
    make setup
    ```


### PR DESCRIPTION
Currently the "quick start" is pointing to a so called "unpulished documentation" site:
>This is the unpublished documentation of wasm-pack, the published documentation is available [on the main Rust and WebAssembly documentation site ](https://rustwasm.github.io/docs/wasm-pack/). Features documented here may not be available in released versions of wasm-pack.

Maybe we should change this link 🤔

![](https://github.com/Kong/atc-router-wasm/assets/24852034/d1b7c246-21d3-4a05-bd54-36ff9aa716d4)
